### PR TITLE
Call amount

### DIFF
--- a/gym_env/env.py
+++ b/gym_env/env.py
@@ -240,7 +240,7 @@ class HoldemTable(Env):
             return
 
         if action == Action.CALL:
-            contribution = min(self.last_player_pot - self.player_pots[self.current_player.seat],
+            contribution = min(self.min_call - self.player_pots[self.current_player.seat],
                                self.current_player.stack)
             self.callers.append(self.current_player.seat)
             self.last_caller = self.current_player.seat

--- a/gym_env/env.py
+++ b/gym_env/env.py
@@ -307,7 +307,7 @@ class HoldemTable(Env):
         self.stage_data[rnd].raises[pos] = action in [Action.RAISE_2POT, Action.RAISE_HAlF_POT, Action.RAISE_POT]
         self.stage_data[rnd].min_call_at_action[pos] = self.min_call
         self.stage_data[rnd].community_pot_at_action[pos] = self.community_pot
-        self.stage_data[rnd].contribution[pos] = contribution
+        self.stage_data[rnd].contribution[pos] += contribution
         self.stage_data[rnd].stack_at_action[pos] = self.current_player.stack
 
         log.info(f"Seat {self.current_player.seat}: {action} - Remaining stack: {self.current_player.stack}, "

--- a/tests/test_gym_env.py
+++ b/tests/test_gym_env.py
@@ -153,20 +153,20 @@ def test_call_proper_amount():
     """Test if a player contributes the correct amount if they call behind a caller who could not cover and went all in"""
     env = _create_env(3)
     raise_size = 2 * (env.small_blind + env.big_blind)
-    """Blinds should have been posted"""
-    assert(env.community_data.current_round_pot == env.big_blind + env.small_blind)
 
-    """Button will raise pot size (2*(sb+bb)), sb will call all in with 1 for a total contribution of sb+1, bb should have to bet 2*sb+bb in order to call"""
+    # Blinds should have been posted
+    assert env.community_data.current_round_pot == env.big_blind + env.small_blind
 
+    # Button will raise pot size (2*(sb+bb)), sb will call all in with 1 for a total contribution of sb+1, bb should have to bet 2*sb+bb in order to call
     env.players[0].stack = raise_size
     env.players[1].stack = 1
     env.players[2].stack = raise_size - env.big_blind
 
     env.step(Action.ALL_IN)  # button raise
-    assert(env.min_call == raise_size)
+    assert env.min_call == raise_size
     env.step(Action.CALL)   # sb calls but does not cover
-    assert(env.min_call == raise_size)
+    assert env.min_call == raise_size
     env.step(Action.CALL)   # bb calls full amount
-    assert(env.stage_data[0].contribution[0] == raise_size)
-    assert(env.stage_data[0].contribution[1] == env.small_blind + 1)
-    assert(env.stage_data[0].contribution[2] == raise_size)
+    assert env.stage_data[0].contribution[0] == raise_size
+    assert env.stage_data[0].contribution[1] == env.small_blind + 1
+    assert env.stage_data[0].contribution[2] == raise_size

--- a/tests/test_gym_env.py
+++ b/tests/test_gym_env.py
@@ -147,3 +147,26 @@ class TestPlayer:
     def action(action):
         """Perform action."""
         return action
+
+
+def test_call_proper_amount():
+    """Test if a player contributes the correct amount if they call behind a caller who could not cover and went all in"""
+    env = _create_env(3)
+    raise_size = 2 * (env.small_blind + env.big_blind)
+    """Blinds should have been posted"""
+    assert(env.community_data.current_round_pot == env.big_blind + env.small_blind)
+
+    """Button will raise pot size (2*(sb+bb)), sb will call all in with 1 for a total contribution of sb+1, bb should have to bet 2*sb+bb in order to call"""
+
+    env.players[0].stack = raise_size
+    env.players[1].stack = 1
+    env.players[2].stack = raise_size - env.big_blind
+
+    env.step(Action.ALL_IN)  # button raise
+    assert(env.min_call == raise_size)
+    env.step(Action.CALL)   # sb calls but does not cover
+    assert(env.min_call == raise_size)
+    env.step(Action.CALL)   # bb calls full amount
+    assert(env.stage_data[0].contribution[0] == raise_size)
+    assert(env.stage_data[0].contribution[1] == env.small_blind + 1)
+    assert(env.stage_data[0].contribution[2] == raise_size)


### PR DESCRIPTION
This adds a test for and fixes #1 

Problem 1: contributions resulting from an action overwrite the current contribution of the round.
This is usually circumvented by having a seperate StageData for a second betting round of the same stage, but blinds are a special case: posting the blinds belongs to the same betting round (hence same StageData) as their usual preflop betting opportunity.

Problem 2: the minimum call amount is properly set at line 271 in gym_env/env.py, but the value is then not being used when determining the call amount in line 222.