### PR TITLE
Fixed loading dqn agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .idea/
 neuron_poker.iml
 log/
+Graph/
+*.pyc

--- a/agents/agent_dqn.py
+++ b/agents/agent_dqn.py
@@ -11,6 +11,11 @@ from rl.policy import BoltzmannQPolicy
 import tensorflow as tf
 import json
 from keras.models import model_from_json
+from keras import Sequential
+from keras.layers import Dense, Dropout
+from rl.memory import SequentialMemory
+from rl.agents import DQNAgent
+from rl.core import Processor
 
 autplay = True  # play automatically if played against keras-rl
 
@@ -39,6 +44,7 @@ class Player:
         self.autoplay = True
 
         self.dqn = None
+        self.model = None
         self.env = env
 
         if load_model:
@@ -46,11 +52,6 @@ class Player:
 
     def initiate_agent(self, env):
         """initiate a deep Q agent"""
-        from keras import Sequential
-        from keras.layers import Dense, Dropout
-        from rl.memory import SequentialMemory
-        from rl.agents import DQNAgent
-
         tf.compat.v1.disable_eager_execution()
         self.env = env
 
@@ -69,7 +70,6 @@ class Player:
         # even the metrics!
         memory = SequentialMemory(limit=memory_limit, window_length=window_length)
         policy = TrumpPolicy()
-        from rl.core import Processor
 
         class CustomProcessor(Processor):
             """The agent and the environment"""
@@ -127,21 +127,16 @@ class Player:
         """Load a model"""
 
         # Load the architecture
-        with open('dqn_in_json.json','r') as f:
-            dqn_json = json.load(f)
+        with open('dqn_in_json.json','r') as architecture_json:
+            dqn_json = json.load(architecture_json)
 
-        self.model = model_from_json(dqn_json)        
+        self.model = model_from_json(dqn_json)
         self.model.load_weights('dqn_{}_weights.h5'.format(env_name))
 
     def play(self, nb_episodes=5, render=False):
-        from keras import Sequential
-        from keras.layers import Dense, Dropout
-        from rl.memory import SequentialMemory
-        from rl.agents import DQNAgent
-        
+        """Let the agent play"""
         memory = SequentialMemory(limit=memory_limit, window_length=window_length)
         policy = TrumpPolicy()
-        from rl.core import Processor
 
         class CustomProcessor(Processor):
             """The agent and the environment"""

--- a/agents/agent_dqn.py
+++ b/agents/agent_dqn.py
@@ -6,13 +6,16 @@ import time
 import numpy as np
 
 from gym_env.env import Action
-from keras.callbacks import TensorBoard
-from rl.policy import BoltzmannQPolicy
+
 import tensorflow as tf
 import json
-from keras.models import model_from_json
+
 from keras import Sequential
+from keras.models import model_from_json
+from keras.callbacks import TensorBoard
 from keras.layers import Dense, Dropout
+
+from rl.policy import BoltzmannQPolicy
 from rl.memory import SequentialMemory
 from rl.agents import DQNAgent
 from rl.core import Processor
@@ -127,7 +130,7 @@ class Player:
         """Load a model"""
 
         # Load the architecture
-        with open('dqn_in_json.json','r') as architecture_json:
+        with open('dqn_in_json.json', 'r') as architecture_json:
             dqn_json = json.load(architecture_json)
 
         self.model = model_from_json(dqn_json)

--- a/agents/agent_dqn.py
+++ b/agents/agent_dqn.py
@@ -8,6 +8,9 @@ import numpy as np
 from gym_env.env import Action
 from keras.callbacks import TensorBoard
 from rl.policy import BoltzmannQPolicy
+import tensorflow as tf
+import json
+from keras.models import model_from_json
 
 autplay = True  # play automatically if played against keras-rl
 
@@ -26,7 +29,7 @@ log = logging.getLogger(__name__)
 class Player:
     """Mandatory class with the player methods"""
 
-    def __init__(self, name='DQN', load_model=None):
+    def __init__(self, name='DQN', load_model=None, env=None):
         """Initiaization of an agent"""
         self.equity_alive = 0
         self.actions = []
@@ -36,7 +39,7 @@ class Player:
         self.autoplay = True
 
         self.dqn = None
-        self.env = None
+        self.env = env
 
         if load_model:
             self.load(load_model)
@@ -44,23 +47,23 @@ class Player:
     def initiate_agent(self, env):
         """initiate a deep Q agent"""
         from keras import Sequential
-        from keras.optimizers import Adam
         from keras.layers import Dense, Dropout
         from rl.memory import SequentialMemory
         from rl.agents import DQNAgent
 
+        tf.compat.v1.disable_eager_execution()
         self.env = env
 
         nb_actions = self.env.action_space.n
 
-        model = Sequential()
-        model.add(Dense(512, activation='relu', input_shape=env.observation_space))
-        model.add(Dropout(0.2))
-        model.add(Dense(512, activation='relu'))
-        model.add(Dropout(0.2))
-        model.add(Dense(512, activation='relu'))
-        model.add(Dropout(0.2))
-        model.add(Dense(nb_actions, activation='linear'))
+        self.model = Sequential()
+        self.model.add(Dense(512, activation='relu', input_shape=env.observation_space))
+        self.model.add(Dropout(0.2))
+        self.model.add(Dense(512, activation='relu'))
+        self.model.add(Dropout(0.2))
+        self.model.add(Dense(512, activation='relu'))
+        self.model.add(Dropout(0.2))
+        self.model.add(Dense(nb_actions, activation='linear'))
 
         # Finally, we configure and compile our agent. You can use every built-in Keras optimizer and
         # even the metrics!
@@ -69,7 +72,7 @@ class Player:
         from rl.core import Processor
 
         class CustomProcessor(Processor):
-            """he agent and the environment"""
+            """The agent and the environment"""
 
             def process_state_batch(self, batch):
                 """
@@ -86,11 +89,11 @@ class Player:
 
         nb_actions = env.action_space.n
 
-        self.dqn = DQNAgent(model=model, nb_actions=nb_actions, memory=memory, nb_steps_warmup=nb_steps_warmup,
+        self.dqn = DQNAgent(model=self.model, nb_actions=nb_actions, memory=memory, nb_steps_warmup=nb_steps_warmup,
                             target_model_update=1e-2, policy=policy,
                             processor=CustomProcessor(),
                             batch_size=batch_size, train_interval=train_interval, enable_double_dqn=enable_double_dqn)
-        self.dqn.compile(Adam(lr=1e-3), metrics=['mae'])
+        self.dqn.compile(tf.optimizers.Adam(lr=1e-3), metrics=['mae'])
 
     def start_step_policy(self, observation):
         """Custom policy for random decisions for warm up."""
@@ -109,6 +112,11 @@ class Player:
         self.dqn.fit(self.env, nb_max_start_steps=nb_max_start_steps, nb_steps=nb_steps, visualize=False, verbose=2,
                      start_step_policy=self.start_step_policy, callbacks=[tensorboard])
 
+        # Save the architecture
+        dqn_json = self.model.to_json()
+        with open("dqn_in_json.json", "w") as json_file:
+            json.dump(dqn_json, json_file)
+
         # After training is done, we save the final weights.
         self.dqn.save_weights('dqn_{}_weights.h5'.format(env_name), overwrite=True)
 
@@ -117,7 +125,49 @@ class Player:
 
     def load(self, env_name):
         """Load a model"""
-        self.dqn.load_weights('dqn_{}_weights.h5'.format(env_name))
+
+        # Load the architecture
+        with open('dqn_in_json.json','r') as f:
+            dqn_json = json.load(f)
+
+        self.model = model_from_json(dqn_json)        
+        self.model.load_weights('dqn_{}_weights.h5'.format(env_name))
+
+    def play(self, nb_episodes=5, render=False):
+        from keras import Sequential
+        from keras.layers import Dense, Dropout
+        from rl.memory import SequentialMemory
+        from rl.agents import DQNAgent
+        
+        memory = SequentialMemory(limit=memory_limit, window_length=window_length)
+        policy = TrumpPolicy()
+        from rl.core import Processor
+
+        class CustomProcessor(Processor):
+            """The agent and the environment"""
+
+            def process_state_batch(self, batch):
+                """
+                Given a state batch, I want to remove the second dimension, because it's
+                useless and prevents me from feeding the tensor into my CNN
+                """
+                return np.squeeze(batch, axis=1)
+
+            def process_info(self, info):
+                processed_info = info['player_data']
+                if 'stack' in processed_info:
+                    processed_info = {'x': 1}
+                return processed_info
+
+        nb_actions = self.env.action_space.n
+
+        self.dqn = DQNAgent(model=self.model, nb_actions=nb_actions, memory=memory, nb_steps_warmup=nb_steps_warmup,
+                            target_model_update=1e-2, policy=policy,
+                            processor=CustomProcessor(),
+                            batch_size=batch_size, train_interval=train_interval, enable_double_dqn=enable_double_dqn)
+        self.dqn.compile(tf.optimizers.Adam(lr=1e-3), metrics=['mae'])
+
+        self.dqn.test(self.env, nb_episodes=nb_episodes, visualize=render)
 
     def action(self, action_space, observation, info):  # pylint: disable=no-self-use
         """Mandatory method that calculates the move based on the observation array and the action space."""

--- a/gym_env/env.py
+++ b/gym_env/env.py
@@ -248,7 +248,7 @@ class HoldemTable(Env):
         self.community_data.current_round_pot = self.current_round_pot / (self.big_blind * 100)
         self.community_data.small_blind = self.small_blind
         self.community_data.big_blind = self.big_blind
-        self.community_data.stage[np.minimum(self.stage.value, 3)] = 1
+        self.community_data.stage[np.minimum(self.stage.value, 3)] = 1 # pylint: disable= invalid-sequence-index
         self.community_data.legal_moves = [action in self.legal_moves for action in Action]
         # self.cummunity_data.active_players
 
@@ -790,7 +790,7 @@ class PlayerCycle:
         while True:
             if self.can_still_make_moves_in_this_hand[self.idx]:
                 break
-            
+
             self.idx += 1
             self.counter += 1
             self.idx %= len(self.lst)
@@ -809,7 +809,7 @@ class PlayerCycle:
         while True:
             if self.can_still_make_moves_in_this_hand[self.dealer_idx]:
                 break
-            
+
             self.dealer_idx += 1
             self.dealer_idx %= len(self.lst)
 

--- a/gym_env/env.py
+++ b/gym_env/env.py
@@ -790,13 +790,13 @@ class PlayerCycle:
         while True:
             if self.can_still_make_moves_in_this_hand[self.idx]:
                 break
-            else:
-                self.idx += 1
-                self.counter += 1
-                self.idx %= len(self.lst)
-                if self.max_steps_total and self.counter >= self.max_steps_total:
-                    log.debug("Max steps total has been reached after jumping some folders")
-                    return False
+            
+            self.idx += 1
+            self.counter += 1
+            self.idx %= len(self.lst)
+            if self.max_steps_total and self.counter >= self.max_steps_total:
+                log.debug("Max steps total has been reached after jumping some folders")
+                return False
 
         self.update_alive()
         return self.lst[self.idx]
@@ -809,9 +809,9 @@ class PlayerCycle:
         while True:
             if self.can_still_make_moves_in_this_hand[self.dealer_idx]:
                 break
-            else:
-                self.dealer_idx += 1
-                self.dealer_idx %= len(self.lst)
+            
+            self.dealer_idx += 1
+            self.dealer_idx %= len(self.lst)
 
         return self.lst[self.dealer_idx]
 

--- a/main.py
+++ b/main.py
@@ -142,7 +142,7 @@ class Runner:
         for improvement_round in range(improvement_rounds):
             env_name = 'neuron_poker-v0'
             stack = 500
-            self.env = gym.make(env_name, num_of_players=5, initial_stacks=stack, render=self.render)
+            self.env = gym.make(env_name, num_of_players=6, initial_stacks=stack, render=self.render)
             for i in range(6):
                 self.env.add_player(EquityPlayer(name=f'Equity/{calling[i]}/{betting[i]}',
                                                  min_call_equity=calling[i],
@@ -175,10 +175,10 @@ class Runner:
         np.random.seed(123)
         env.seed(123)
         env.add_player(EquityPlayer(name='equity/50/70', min_call_equity=.5, min_bet_equity=.7))
-        # env.add_player(EquityPlayer(name='equity/20/30', min_call_equity=.2, min_bet_equity=-.3))
-        # env.add_player(RandomPlayer())
-        # env.add_player(RandomPlayer())
-        # env.add_player(RandomPlayer())
+        env.add_player(EquityPlayer(name='equity/20/30', min_call_equity=.2, min_bet_equity=.3))
+        env.add_player(RandomPlayer())
+        env.add_player(RandomPlayer())
+        env.add_player(RandomPlayer())
         env.add_player(PlayerShell(name='keras-rl', stack_size=stack))  # shell is used for callback to keras rl
 
         env.reset()
@@ -193,15 +193,17 @@ class Runner:
         stack = 500
         num_of_plrs = 6
         self.env = gym.make(env_name, num_of_players=num_of_plrs, initial_stacks=stack, render=self.render)
-        self.env.add_player(EquityPlayer(name='equity/50/50', min_call_equity=.5, min_bet_equity=-.5))
-        self.env.add_player(EquityPlayer(name='equity/50/80', min_call_equity=.8, min_bet_equity=-.8))
-        self.env.add_player(EquityPlayer(name='equity/70/70', min_call_equity=.7, min_bet_equity=-.7))
-        self.env.add_player(EquityPlayer(name='equity/20/30', min_call_equity=.2, min_bet_equity=-.3))
+        self.env.add_player(EquityPlayer(name='equity/50/50', min_call_equity=.5, min_bet_equity=.5))
+        self.env.add_player(EquityPlayer(name='equity/50/80', min_call_equity=.8, min_bet_equity=.8))
+        self.env.add_player(EquityPlayer(name='equity/70/70', min_call_equity=.7, min_bet_equity=.7))
+        self.env.add_player(EquityPlayer(name='equity/20/30', min_call_equity=.2, min_bet_equity=.3))
         self.env.add_player(RandomPlayer())
-        self.env.add_player(DQNPlayer(load_model='neuron_poker-v0'))
+        self.env.add_player(PlayerShell(name='keras-rl', stack_size=stack))
 
-        for _ in range(self.num_episodes):
-            self.env.reset()
+        self.env.reset()
+
+        dqn = DQNPlayer(load_model='dqn1', env=self.env)
+        dqn.play(nb_episodes=self.num_episodes, render=self.render)
 
 
 if __name__ == '__main__':

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -3,8 +3,11 @@
 
 import datetime
 import logging
+
 import multiprocessing
+from multiprocessing.pool import ThreadPool
 import os
+
 import pickle
 import sys
 import traceback
@@ -221,7 +224,7 @@ def multi_threading(pool_fn, pool_args, disable_multiprocessing=False, dataframe
         res (list): Result of multiprocessing. Len of results will match len of the list of the pool_args
 
     """
-    from multiprocessing.pool import ThreadPool
+    
     parallel, cores = get_multiprocessing_config()
     log.debug("Start with parallel={} and cores={}, queue size={}".format(parallel, cores, len(pool_args)))
     if parallel and not disable_multiprocessing:

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -224,7 +224,7 @@ def multi_threading(pool_fn, pool_args, disable_multiprocessing=False, dataframe
         res (list): Result of multiprocessing. Len of results will match len of the list of the pool_args
 
     """
-    
+
     parallel, cores = get_multiprocessing_config()
     log.debug("Start with parallel={} and cores={}, queue size={}".format(parallel, cores, len(pool_args)))
     if parallel and not disable_multiprocessing:


### PR DESCRIPTION
Resolves [this issue](https://github.com/dickreuter/neuron_poker/issues/16).

- To be able to load the agent one also needs to load the architecture not only the weights. I changed how to play the agent in the same way as we train the agent. 
- I also changed the Adam optimizer to tensorflow optimizer `tf.optimizers.Adam` since the keras `Adam` threw errors on my machine
- added also the line `tf.compat.v1.disable_eager_execution()` since it also threw me an error without it
- also changed `min_bet_equity=-.5` -> `min_bet_equity=.5` without the minus not sure if it was intentional

Nice project btw. Pls review my changes :)