### PR TITLE
Added: New test for a round where no one raise, should the big do bli…

### DIFF
--- a/agents/agent_keras_rl_dqn.py
+++ b/agents/agent_keras_rl_dqn.py
@@ -190,6 +190,10 @@ class TrumpPolicy(BoltzmannQPolicy):
 class CustomProcessor(Processor):
     """The agent and the environment"""
 
+    def __init__(self):
+        """initizlie properties"""
+        self.legal_moves_limit = None
+
     def process_state_batch(self, batch):
         """Remove second dimension to make it possible to pass it into cnn"""
         return np.squeeze(batch, axis=1)

--- a/tests/test_gym_env.py
+++ b/tests/test_gym_env.py
@@ -59,7 +59,7 @@ def test_no_player_raise_big_blind_do_last_action_in_round():
 
     env.step(Action.CHECK)
 
-    assert env.stage == env.stage.FLOP
+    assert env.stage == Stage.FLOP
 
 
 def test_heads_up_after_flop():


### PR DESCRIPTION
Added: New test for a round where no one raise, should the big do blind the last action.
Fix: For added test and check is now a legal move when pot of current player is equal than the highest stack in round.
Change: Rename test and adapt test to new fixes

If you have some questions just let me know