### PR TITLE
Update compiler_args to support c++17 compiler (for Visual Studio 2019)

### DIFF
--- a/tools/montecarlo_cpp/pymontecarlo.cpp
+++ b/tools/montecarlo_cpp/pymontecarlo.cpp
@@ -1,5 +1,5 @@
 <%
-cfg['compiler_args'] = ['-std=c++14']
+cfg['compiler_args'] = ['/std:c++17']
 setup_pybind11(cfg)
 cfg['sources'] = ['Montecarlo.cpp']
 %>


### PR DESCRIPTION
Fix #46 