### PR TITLE
add optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,11 @@ docopt = "^0.6.2"
 pydocstyle = "^6.3.0"
 matplotlib = "^3.8.2"
 mpld3 = "^0.5.10"
+tensorflow = { version = "<=2.15", optional = true }
+keras-rl = { version = "*", optional = true }
 
+[tool.poetry.extras]
+rl = [ "tensorflow", "keras-rl"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/readme.rst
+++ b/readme.rst
@@ -20,7 +20,8 @@ Run:
 - To manually control the players:``poetry run python main.py selfplay keypress --render``
 - Example of genetic algorithm with self improvement: ``poetry run python main.py selfplay equity_improvement --improvement_rounds=20 --episodes=10``
 - In order to use the C++ version of the equity calculator, you will also need to install Visual Studio 2019 (or GCC over Cygwin may work as well). To use it, use the -c option when running main.py.
-- For more advanced users: ``poetry run python main.py selfplay dqn_train -c`` will start training the deep Q agent with C++ Monte Carlo for faster calculation
+- For more advanced users: ``poetry run python main.py selfplay dqn_train -c`` will start training the deep Q agent with C++ Monte Carlo for faster calculation.
+  This requires tensorflow: ``poetry install --no-root --extras rl``
 
 .. figure:: doc/table.gif
    :alt:


### PR DESCRIPTION
This adds tensorflow and keras-rl as extra dependencies. These are required by dqn_train but not explicitly listed. Additionally, this requires tensorflow <= 2.15, which should solve #88 .